### PR TITLE
fix(checkout): always charge fixed mailbox price for mailbox packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# Version 2.8.1
+
+#### Improvements
+
+- fix: fixed mailbox price is now always charged for a mailbox package instead of being capped by the (lower) regular shipping costs; free shipping still stays free
+- fix: the "activate fixed mailbox price" toggle is now honored, so a fixed mailbox price of 0 can be configured
+
 # Version 2.8.0
 
 #### New features

--- a/CHANGELOG_de-DE.md
+++ b/CHANGELOG_de-DE.md
@@ -1,3 +1,10 @@
+# Version 2.8.1
+
+#### Verbesserungen
+
+- fix: Der feste Mailbox-Paket-Preis wird bei einem Mailbox-Paket jetzt immer berechnet, statt auf die (niedrigeren) regulären Versandkosten begrenzt zu werden; kostenloser Versand bleibt kostenlos
+- fix: Die Schaltfläche "festen Mailbox-Paket-Preis aktivieren" wird jetzt berücksichtigt, sodass ein fester Preis von 0 konfiguriert werden kann
+
 # Version 2.7.0
 
 #### Neue Funktionen

--- a/CHANGELOG_nl-NL.md
+++ b/CHANGELOG_nl-NL.md
@@ -1,3 +1,10 @@
+# Versie 2.8.1
+
+#### Verbeteringen
+
+- fix: vaste prijs brievenbuspakje wordt nu altijd berekend bij een brievenbuspakje in plaats van afgetopt op de (lagere) reguliere verzendkosten; gratis verzending blijft gratis
+- fix: de knop "activeer vaste prijs brievenbuspakje" wordt nu gerespecteerd, zodat een vaste prijs van 0 kan worden ingesteld
+
 # Version 2.7.0
 
 #### Nieuwe functies

--- a/CHANGELOG_nl-NL.md
+++ b/CHANGELOG_nl-NL.md
@@ -1,4 +1,4 @@
-# Versie 2.8.1
+# Version 2.8.1
 
 #### Verbeteringen
 

--- a/src/Core/Checkout/Cart/Delivery/DeliveryCalculatorDecorator.php
+++ b/src/Core/Checkout/Cart/Delivery/DeliveryCalculatorDecorator.php
@@ -238,7 +238,7 @@ class DeliveryCalculatorDecorator extends DeliveryCalculator
 
         $price = $this->getCurrencyPrice($priceCollection, $context);
 
-        $hasChargeableItems = $calculatedLineItems->filter(static function($lineItem){
+        $chargeableItemCount = $calculatedLineItems->filter(static function($lineItem){
             if (!$lineItem->getDeliveryInformation()) {
                 return false;
             }
@@ -248,7 +248,7 @@ class DeliveryCalculatorDecorator extends DeliveryCalculator
             return true;
         })->count();
 
-        $shippingIsFree = 0 === $hasChargeableItems;
+        $shippingIsFree = 0 === $chargeableItemCount;
 
         if ($shippingIsFree) {
             $price = 0;

--- a/src/Core/Checkout/Cart/Delivery/DeliveryCalculatorDecorator.php
+++ b/src/Core/Checkout/Cart/Delivery/DeliveryCalculatorDecorator.php
@@ -238,7 +238,7 @@ class DeliveryCalculatorDecorator extends DeliveryCalculator
 
         $price = $this->getCurrencyPrice($priceCollection, $context);
 
-        if (!$calculatedLineItems->filter(static function($lineItem){
+        $hasChargeableItems = $calculatedLineItems->filter(static function($lineItem){
             if (!$lineItem->getDeliveryInformation()) {
                 return false;
             }
@@ -246,7 +246,11 @@ class DeliveryCalculatorDecorator extends DeliveryCalculator
                 return false;
             }
             return true;
-        })->count()) {
+        })->count();
+
+        $shippingIsFree = 0 === $hasChargeableItems;
+
+        if ($shippingIsFree) {
             $price = 0;
         }
 
@@ -306,7 +310,8 @@ class DeliveryCalculatorDecorator extends DeliveryCalculator
             $price        = $this->configGenerator->getCostForCarrierWithOptions(
                 $deliveryData,
                 $context->getSalesChannelId(),
-                $price
+                $price,
+                $shippingIsFree
             );
         }
         $definition = new QuantityPriceDefinition($price, $rules, 1);

--- a/src/Service/Config/ConfigGenerator.php
+++ b/src/Service/Config/ConfigGenerator.php
@@ -46,6 +46,8 @@ class ConfigGenerator
      * Calculates the cost based on the selected options
      * @param array  $options
      * @param string $salesChannelId
+     * @param float  $totalPrice
+     * @param bool   $shippingIsFree
      * @return float
      */
     public function getCostForCarrierWithOptions(array $options, string $salesChannelId, float $totalPrice, bool $shippingIsFree = false): float

--- a/src/Service/Config/ConfigGenerator.php
+++ b/src/Service/Config/ConfigGenerator.php
@@ -14,6 +14,12 @@ class ConfigGenerator
         'deliveryDaysWindow',
         'dropOffDelay',
         'cutoffTime',
+        /*
+         * The fixed mailbox price has a dedicated enable toggle (priceMailboxEnabled<carrier>) separate from
+         * the price value (priceMailbox<carrier>). Without this entry isSettingEnabled() would read the price
+         * field as the toggle, ignoring the actual toggle and never applying a configured price of 0.
+         */
+        'priceMailbox',
     ];
 
     /**
@@ -42,7 +48,7 @@ class ConfigGenerator
      * @param string $salesChannelId
      * @return float
      */
-    public function getCostForCarrierWithOptions(array $options, string $salesChannelId, float $totalPrice): float
+    public function getCostForCarrierWithOptions(array $options, string $salesChannelId, float $totalPrice, bool $shippingIsFree = false): float
     {
         /**
          * Settings with a cost:
@@ -54,7 +60,16 @@ class ConfigGenerator
         $carrier = MyParcelCarriers::NPM_CARRIER_TO_CONFIG_CARRIER[$options['carrier']];
 
         if (isset($options['packageType']) && AbstractConsignment::PACKAGE_TYPE_MAILBOX_NAME === $options['packageType'] && $this->isSettingEnabled($salesChannelId, 'priceMailbox', $carrier)) {
-            return min ($totalPrice, $this->getConfigFloat($salesChannelId, 'priceMailbox', $carrier));
+            /**
+             * The mailbox price is a fixed price: when a mailbox package is chosen it must always be charged,
+             * regardless of the (possibly lower) regular shipping costs. The only exception is free shipping
+             * (e.g. a product with the free shipping setting, see #77), which must stay free.
+             */
+            if ($shippingIsFree) {
+                return $totalPrice;
+            }
+
+            return $this->getConfigFloat($salesChannelId, 'priceMailbox', $carrier);
         }
 
         //Is it pickup?


### PR DESCRIPTION
INT-1675

## Summary

The "vaste prijs brievenbuspakje" (fixed mailbox price) setting had no effect at checkout.

**Root cause:** in `ConfigGenerator::getCostForCarrierWithOptions()` the mailbox price was applied as `min($regularShippingCost, $mailboxPrice)`. That `min()` was introduced in #77 to keep free-shipping orders free, but it also means that whenever the regular MyParcel shipping cost is **lower** than the configured fixed price (e.g. a shipping-method base price of 0), the fixed price is never charged — so the setting silently does nothing.

## Changes

- **Fixed price is always charged for a mailbox package**, regardless of the (possibly lower) regular shipping costs — except genuine free-shipping orders, which stay free (so #77 is preserved). The decorator now passes a `$shippingIsFree` flag it already computes.
- **Honor the enable toggle.** `isSettingEnabled('priceMailbox', …)` read the *price* field instead of `priceMailboxEnabled<carrier>`, so the toggle was ignored and a fixed price of `0` could never apply. Added `priceMailbox` to `FIELDS_WITH_ENABLED_PREFIX`.
- Changelog entries (EN/NL/DE) under 2.8.1.

## Test plan

Verified against a local SW 6.6 install (NL shipping address, light product, `packageType=mailbox`, `priceMailboxEnabledPostNL=true`, `priceMailboxPostNL=2.95`):

| Scenario | Before | After |
|---|---|---|
| mailbox, base €0.00 | 0.00 ❌ | **2.95** ✅ |
| mailbox, base €1.00 | 1.00 ❌ | **2.95** ✅ |
| mailbox, base €6.95 | 2.95 | 2.95 ✅ |
| mailbox, free-shipping product | 0.00 | **0.00** ✅ (#77 preserved) |
| package (non-mailbox), base €6.95 | 6.95 | 6.95 ✅ |
| enable toggle OFF | price applied ❌ | **not applied** ✅ |
| toggle ON + price €0.00 | not applied ❌ | **0.00 applied** ✅ |
| NL cart end-to-end, base €0 | 0.00 ❌ | **2.95** ✅ |

`php -l` clean on both changed files; `bin/console lint:container` green.

## Note

Not a Shopware 6.6 regression — the `min()` has been present since #77 (Aug 2024); it surfaces whenever the regular shipping cost is below the fixed mailbox price.
