### PR TITLE
chore: update to 2.8.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "mypashopware/myparcel",
     "description": "MyParcel integration for Shopware 6",
-    "version": "2.8.0",
+    "version": "2.8.1",
     "type": "shopware-platform-plugin",
     "license": "proprietary",
     "authors": [


### PR DESCRIPTION
Bumps the plugin version in `composer.json` from 2.8.0 to 2.8.1 for the 2.8.1 release (mailbox fixed-price fix, #86).

The CHANGELOG entries for 2.8.1 already landed via #86; this only bumps the version so the built plugin and store publish report 2.8.1.