### PR TITLE
fix(build): quote Shopware version constraint in makefile

### DIFF
--- a/makefile
+++ b/makefile
@@ -14,9 +14,9 @@ help:
 # ------------------------------------------------------------------------------------------------------------
 
 install-prod: ## Installs only production dependencies
-	@php update-composer-require.php --env=prod --shopware=$(SHOPWARE_COMPATIBILIY)
+	@php update-composer-require.php --env=prod --shopware="$(SHOPWARE_COMPATIBILIY)"
 	@composer install --no-dev --no-scripts --no-interaction --optimize-autoloader
-	@php update-composer-require.php --env=prod --shopware=$(SHOPWARE_COMPATIBILIY) --release
+	@php update-composer-require.php --env=prod --shopware="$(SHOPWARE_COMPATIBILIY)" --release
 	@yarn workspaces focus
 	@yarn install --immutable
 


### PR DESCRIPTION
## Summary

`make install-prod` (and therefore `make release`) failed with `/bin/sh: can't open 6.7`.

The `SHOPWARE_COMPATIBILIY` variable is `>=6.5.8 <6.7`. Unquoted, the shell interpreted `<6.7` in `--shopware=$(SHOPWARE_COMPATIBILIY)` as an **input redirect**, so `update-composer-require.php` never received the constraint and the recipe aborted.

Quoting the value (`--shopware="$(SHOPWARE_COMPATIBILIY)"`) passes it verbatim.

## Test plan
- `make release` / `make install-prod` now runs the prod dependency switch without the redirect error (verified locally; produced a valid slim MyPaShopware-2.8.1.zip).